### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, main]


### PR DESCRIPTION
Potential fix for [https://github.com/YuujiKamura/photo-ai-rust/security/code-scanning/1](https://github.com/YuujiKamura/photo-ai-rust/security/code-scanning/1)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimal set required. This workflow only checks out code, installs Rust, caches build artifacts, builds, tests, runs clippy, and uploads build artifacts; none of these require write access to repository contents or other GitHub resources. Therefore, setting `contents: read` at the workflow root is sufficient and will apply to both `build` and `release-build` jobs.

Concretely, in `.github/workflows/ci.yml`, add a top‑level `permissions:` block right after the `name: CI` (before `on:`). Set it to `contents: read` as a minimal starting point. No other files or imports are involved, and no existing steps need to be changed. This preserves existing behavior while ensuring the `GITHUB_TOKEN` is limited to read‑only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
