### PR TITLE
Potential fix for code scanning alert no. 6: Cleartext transmission of sensitive information

### DIFF
--- a/tests/gemini_integration_test.rs
+++ b/tests/gemini_integration_test.rs
@@ -38,7 +38,8 @@ async fn gemini_step1_integration() {
 
     let client = reqwest::Client::new();
     let response = client
-        .post(format!("{}?key={}", GEMINI_API_URL, api_key))
+        .post(GEMINI_API_URL)
+        .header("x-goog-api-key", api_key)
         .json(&body)
         .send()
         .await


### PR DESCRIPTION
Potential fix for [https://github.com/YuujiKamura/photo-ai-rust/security/code-scanning/6](https://github.com/YuujiKamura/photo-ai-rust/security/code-scanning/6)

In general, the fix is to avoid including sensitive data such as API keys in URLs (path or query string) and instead send them in HTTP headers or, where supported, in the encrypted request body. This reduces the risk of accidental logging or exposure via intermediaries. For this specific code, we should stop interpolating `api_key` into the request URL and instead send it using the standard `x-goog-api-key` header used by Google’s Generative Language API. The rest of the request (body, method, URL path) remains unchanged, so functionality is preserved.

Concretely, in `tests/gemini_integration_test.rs`, replace the `.post(format!("{}?key={}", GEMINI_API_URL, api_key))` call with `.post(GEMINI_API_URL).header("x-goog-api-key", api_key)`. This keeps the same endpoint (`GEMINI_API_URL`) while moving the key to a header. No new imports are needed because we already use `reqwest::Client`, and the `header` method is available by default. No other lines in the file need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
